### PR TITLE
Overhaul stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Titan Core simplifies this process with a declarative Python approach. It allows
 | Hybrid Table                  | WIP        |
 | Iceberg Table                 | ❌         |
 | Image Repository              | ✅         |
-| Internal Stage                | WIP       |
+| Internal Stage                | ✅         |
 | Masking Policy                | ❌         |
 | Materialized View             | ✅         |
 | Model                         | ❌         |

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="titan",
-    version="0.4.0",
+    version="0.4.1",
     description="Snowflake infrastructure as code",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/tests/fixtures/json/external_stage.json
+++ b/tests/fixtures/json/external_stage.json
@@ -9,15 +9,9 @@
         "type": "AWS_SSE_KMS",
         "kms_key_id": "alias/MyAliasName"
     },
-    "file_format": null,
     "directory": {
         "enable": true,
         "refresh_on_create": true
-    },
-    "copy_options": {
-        "on_error": "CONTINUE",
-        "size_limit": 100,
-        "purge": true
     },
     "tags": null,
     "comment": "This is an example of an external stage"

--- a/tests/fixtures/json/internal_stage.json
+++ b/tests/fixtures/json/internal_stage.json
@@ -5,20 +5,9 @@
     "encryption": {
         "type": "SNOWFLAKE_SSE"
     },
-    "file_format": null,
     "directory": {
         "enable": true,
         "refresh_on_create": false
-    },
-    "copy_options": {
-        "on_error": "CONTINUE",
-        "size_limit": 100,
-        "purge": true,
-        "return_failed_only": false,
-        "match_by_column_name": "CASE_SENSITIVE",
-        "enforce_length": true,
-        "truncatecolumns": false,
-        "force": false
     },
     "tags": null,
     "comment": "This is an example of an internal stage."

--- a/tests/fixtures/sql/stage.sql
+++ b/tests/fixtures/sql/stage.sql
@@ -1,25 +1,14 @@
-CREATE STAGE foob ENCRYPTION = (TYPE = 'SNOWFLAKE_FULL');
-CREATE STAGE my_int_stage_1
-  COPY_OPTIONS = (
-    ON_ERROR='skip_file'
-    MATCH_BY_COLUMN_NAME = CASE_INSENSITIVE
-    ENFORCE_LENGTH = FALSE
-    TRUNCATECOLUMNS = TRUE
-    FORCE = FALSE
-);
+CREATE STAGE stage_with_encryption
+  ENCRYPTION = (TYPE = 'SNOWFLAKE_FULL');
+
+CREATE STAGE my_int_stage_1;
+
 CREATE STAGE my_int_stage_2
-  ENCRYPTION = (TYPE = 'SNOWFLAKE_SSE')
-  COPY_OPTIONS = (ON_ERROR= skip_file);
-CREATE TEMPORARY STAGE my_temp_int_stage;
-CREATE TEMPORARY STAGE my_int_stage_tmp
-  FILE_FORMAT = my_csv_format;
-CREATE STAGE mystage
+  ENCRYPTION = (TYPE = 'SNOWFLAKE_SSE');
+
+CREATE STAGE stage_with_directory
   DIRECTORY = (ENABLE = TRUE)
-  FILE_FORMAT = (FORMAT_NAME=nested_format_name);
+  COMMENT = 'This is a stage with a directory';
 
-CREATE OR REPLACE STAGE LOAD_STAGE
+CREATE OR REPLACE STAGE s3_external_stage
     url = 'https://s3.amazonaws.com/tripdata/';
-
-CREATE STAGE stage_with_anon_file_format
-  FILE_FORMAT = (TYPE = CSV FIELD_DELIMITER = '|' SKIP_HEADER = 1)
-;

--- a/titan/__init__.py
+++ b/titan/__init__.py
@@ -20,7 +20,7 @@ __all__ = [
     "Warehouse",
 ]
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 LOGO = r"""
     __  _ __          

--- a/titan/data_provider.py
+++ b/titan/data_provider.py
@@ -1131,7 +1131,7 @@ def fetch_resource_tags(session, resource_type: ResourceType, fqn: FQN):
         session,
         f"""
             SELECT *
-            FROM table({database}.information_schema.tag_references(
+            FROM table({database}information_schema.tag_references(
                 '{fqn}', '{str(resource_type)}'
             ))""",
     )

--- a/titan/data_provider.py
+++ b/titan/data_provider.py
@@ -1125,11 +1125,13 @@ def fetch_resource_tags(session, resource_type: ResourceType, fqn: FQN):
 
     """
 
+    database = f"{fqn.database}." if fqn.database else ""
+
     tag_refs = execute(
         session,
         f"""
             SELECT *
-            FROM table({fqn.database}.information_schema.tag_references(
+            FROM table({database}.information_schema.tag_references(
                 '{fqn}', '{str(resource_type)}'
             ))""",
     )

--- a/titan/data_provider.py
+++ b/titan/data_provider.py
@@ -61,7 +61,6 @@ def _desc_type3_result_to_dict(desc_result, lower_properties=False):
         elif row["property_type"] == "List":
             value = _parse_list_property(value)
         result[parent_property][property] = value
-        print(parent_property, property, value)
     return result
 
 
@@ -1125,9 +1124,6 @@ def fetch_resource_tags(session, resource_type: ResourceType, fqn: FQN):
     +----------------------+------------+-------------+-----------+--------+----------------------+---------------+-------------+--------+-------------+
 
     """
-
-    if resource_type != ResourceType.SCHEMA or not isinstance(resource_type, ResourceType):
-        raise NotImplementedError
 
     tag_refs = execute(
         session,

--- a/titan/data_provider.py
+++ b/titan/data_provider.py
@@ -38,6 +38,33 @@ def _desc_type2_result_to_dict(desc_result, lower_properties=False):
     )
 
 
+def _desc_type3_result_to_dict(desc_result, lower_properties=False):
+    result = {}
+    for row in desc_result:
+        parent_property = row["parent_property"]
+        property = row["property"]
+        if lower_properties:
+            parent_property = parent_property.lower()
+            property = property.lower()
+        if parent_property not in result:
+            result[parent_property] = {}
+
+        value = row["property_value"]
+        if row["property_type"] == "Boolean":
+            value = value == "true"
+        elif row["property_type"] == "Long":
+            value = value or None
+        elif row["property_type"] == "Integer":
+            value = int(value)
+        elif row["property_type"] == "String":
+            value = value or None
+        elif row["property_type"] == "List":
+            value = _parse_list_property(value)
+        result[parent_property][property] = value
+        print(parent_property, property, value)
+    return result
+
+
 def _fail_if_not_granted(result, *args):
     if len(result) == 0:
         raise Exception("Failed to create grant")
@@ -124,12 +151,12 @@ def _parse_function_arguments(arguments_str: str) -> tuple:
     return (identifier, returns)
 
 
-def _parse_imports(imports: str) -> list:
-    if imports is None:
+def _parse_list_property(property_str: str) -> list:
+    if property_str is None:
         return []
-    imports = imports.strip("[]")
-    if imports:
-        return [imp.strip(" ") for imp in imports.split(",")]
+    property_str = property_str.strip("[]")
+    if property_str:
+        return [item.strip(" ") for item in property_str.split(",")]
     return []
 
 
@@ -661,7 +688,7 @@ def fetch_procedure(session, fqn: FQN):
         "comment": data["description"],
         "execute_as": properties["execute as"],
         "handler": properties["handler"],
-        "imports": _parse_imports(properties["imports"]),
+        "imports": _parse_list_property(properties["imports"]),
         "language": properties["language"],
         "null_handling": properties["null handling"],
         "owner": ownership_grant[0]["grantee_name"] if len(ownership_grant) > 0 else None,
@@ -917,6 +944,10 @@ def fetch_stage(session, fqn: FQN):
         raise Exception(f"Found multiple stages matching {fqn}")
 
     data = stages[0]
+    desc_result = execute(session, f"DESC STAGE {fqn.name}")
+    properties = _desc_type3_result_to_dict(desc_result, lower_properties=True)
+    tags = fetch_resource_tags(session, ResourceType.STAGE, fqn)
+
     if data["type"] == "EXTERNAL":
         return {
             "name": data["name"],
@@ -924,20 +955,21 @@ def fetch_stage(session, fqn: FQN):
             "owner": data["owner"],
             "type": data["type"],
             "storage_integration": data["storage_integration"],
-            # "credentials": data["credentials"],
-            # "encryption": data["encryption"],
-            # "file_format": data["file_format"],
             "directory": {"enable": data["directory_enabled"] == "Y"},
-            # "copy_options": data["copy_options"],
-            # "tags": data["tags"],
+            "tags": tags,
+            "comment": data["comment"] or None,
+        }
+    elif data["type"] == "INTERNAL":
+        return {
+            "name": data["name"],
+            "owner": data["owner"],
+            "type": data["type"],
+            "directory": {"enable": data["directory_enabled"] == "Y"},
+            "tags": tags,
             "comment": data["comment"] or None,
         }
     else:
         raise Exception(f"Unsupported stage type {data['type']}")
-        return {
-            "name": data["name"],
-            "owner": data["owner"],
-        }
 
 
 def fetch_storage_integration(session, fqn: FQN):

--- a/titan/props.py
+++ b/titan/props.py
@@ -321,9 +321,10 @@ class ReturnsProp(Prop):
 
 
 class EnumProp(Prop):
-    def __init__(self, label, enum_or_list, **kwargs):
+    def __init__(self, label, enum_or_list, quoted=False, **kwargs):
         self.enum_type = type(enum_or_list[0]) if isinstance(enum_or_list, list) else enum_or_list
         self.valid_values = set(enum_or_list)
+        self.quoted = quoted
         value_expr = pp.MatchFirst([Keywords(val.value) for val in self.valid_values]) | (~Keyword("NULL") + ANY())
         super().__init__(label, value_expr, **kwargs)
 
@@ -339,7 +340,9 @@ class EnumProp(Prop):
         if value is None:
             return ""
         eq = " = " if self.eq else " "
-        return f"{self.label}{eq}{str(value)}"
+        if self.quoted:
+            value = f"'{value}'"
+        return f"{self.label}{eq}{value}"
 
 
 class EnumListProp(Prop):

--- a/titan/resources/alert.py
+++ b/titan/resources/alert.py
@@ -32,6 +32,17 @@ class Alert(Resource):
         owner (str, optional): The owner of the alert. Defaults to "SYSADMIN".
         comment (str, optional): A comment for the alert. Defaults to None.
         tags (dict[str, str], optional): Tags for the alert. Defaults to None.
+
+    CREATE [ OR REPLACE ] ALERT [ IF NOT EXISTS ] <name>
+        [ WAREHOUSE = <warehouse_name> ]
+        SCHEDULE = '{ <num> MINUTE | USING CRON <expr> <time_zone> }'
+        COMMENT = '<string_literal>'
+        [ [ WITH ] TAG ( <tag_name> = '<tag_value>' [ , <tag_name> = '<tag_value>' , ... ] ) ]
+        IF( EXISTS(
+            <condition>
+        ))
+        THEN
+            <action>
     """
 
     resource_type = ResourceType.ALERT

--- a/titan/resources/stage.py
+++ b/titan/resources/stage.py
@@ -1,5 +1,4 @@
-from dataclasses import dataclass
-from typing import Union
+from dataclasses import dataclass, field
 
 from .resource import Resource, ResourceSpec
 from ..enums import ParseableEnum, ResourceType
@@ -8,7 +7,6 @@ from ..props import (
     BoolProp,
     EnumProp,
     IdentifierProp,
-    IntProp,
     Props,
     PropSet,
     StringProp,
@@ -32,27 +30,27 @@ class EncryptionType(ParseableEnum):
     NONE = "NONE"
 
 
-"""
-copyOptions ::=
-     ON_ERROR = { CONTINUE | SKIP_FILE | SKIP_FILE_<num> | 'SKIP_FILE_<num>%' | ABORT_STATEMENT }
-     SIZE_LIMIT = <num>
-     PURGE = TRUE | FALSE
-     RETURN_FAILED_ONLY = TRUE | FALSE
-     MATCH_BY_COLUMN_NAME = CASE_SENSITIVE | CASE_INSENSITIVE | NONE
-     ENFORCE_LENGTH = TRUE | FALSE
-     TRUNCATECOLUMNS = TRUE | FALSE
-     FORCE = TRUE | FALSE
-"""
-copy_options = Props(
-    on_error=StringProp("on_error", alt_tokens=["CONTINUE", "SKIP_FILE", "ABORT_STATEMENT"]),
-    size_limit=IntProp("size_limit"),
-    purge=BoolProp("purge"),
-    return_failed_only=BoolProp("return_failed_only"),
-    match_by_column_name=StringProp("match_by_column_name", alt_tokens=["CASE_SENSITIVE", "CASE_INSENSITIVE", "NONE"]),
-    enforce_length=BoolProp("enforce_length"),
-    truncatecolumns=BoolProp("truncatecolumns"),
-    force=BoolProp("force"),
-)
+# """
+# copyOptions ::=
+#      ON_ERROR = { CONTINUE | SKIP_FILE | SKIP_FILE_<num> | 'SKIP_FILE_<num>%' | ABORT_STATEMENT }
+#      SIZE_LIMIT = <num>
+#      PURGE = TRUE | FALSE
+#      RETURN_FAILED_ONLY = TRUE | FALSE
+#      MATCH_BY_COLUMN_NAME = CASE_SENSITIVE | CASE_INSENSITIVE | NONE
+#      ENFORCE_LENGTH = TRUE | FALSE
+#      TRUNCATECOLUMNS = TRUE | FALSE
+#      FORCE = TRUE | FALSE
+# """
+# copy_options = Props(
+#     on_error=StringProp("on_error", alt_tokens=["CONTINUE", "SKIP_FILE", "ABORT_STATEMENT"]),
+#     size_limit=IntProp("size_limit"),
+#     purge=BoolProp("purge"),
+#     return_failed_only=BoolProp("return_failed_only"),
+#     match_by_column_name=StringProp("match_by_column_name", alt_tokens=["CASE_SENSITIVE", "CASE_INSENSITIVE", "NONE"]),
+#     enforce_length=BoolProp("enforce_length"),
+#     truncatecolumns=BoolProp("truncatecolumns"),
+#     force=BoolProp("force"),
+# )
 
 
 @dataclass(unsafe_hash=True)
@@ -60,10 +58,8 @@ class _InternalStage(ResourceSpec):
     name: str
     owner: str = "SYSADMIN"
     type: StageType = StageType.INTERNAL
-    encryption: dict[str, EncryptionType] = None
-    file_format: Union[str, dict[str, str]] = None  #  Union[str, dict]
+    encryption: dict[str, EncryptionType] = field(default_factory=None, metadata={"fetchable": False})
     directory: dict[str, bool] = None
-    copy_options: dict[str, str] = None
     tags: dict[str, str] = None
     comment: str = None
 
@@ -71,11 +67,11 @@ class _InternalStage(ResourceSpec):
         super().__post_init__()
         if self.type != StageType.INTERNAL:
             raise ValueError("Type must be INTERNAL for _InternalStage")
-        if self.encryption and self.encryption["type"] not in [
-            EncryptionType.SNOWFLAKE_FULL,
-            EncryptionType.SNOWFLAKE_SSE,
-        ]:
-            raise ValueError("Encryption type must be SNOWFLAKE_FULL or SNOWFLAKE_SSE for InternalStage")
+        if self.encryption:
+            if "type" not in self.encryption:
+                raise ValueError("When specifying encryption, 'type' is required")
+            if self.encryption["type"] not in [EncryptionType.SNOWFLAKE_FULL, EncryptionType.SNOWFLAKE_SSE]:
+                raise ValueError("Encryption 'type' must be SNOWFLAKE_FULL or SNOWFLAKE_SSE for InternalStage")
 
 
 class InternalStage(Resource):
@@ -84,11 +80,8 @@ class InternalStage(Resource):
     CREATE [ OR REPLACE ] [ { TEMP | TEMPORARY } ] STAGE [ IF NOT EXISTS ] <internal_stage_name>
         internalStageParams
         directoryTableParams
-      [ FILE_FORMAT = ( { FORMAT_NAME = '<file_format_name>'
-                         | TYPE = { CSV | JSON | AVRO | ORC | PARQUET | XML } [ formatTypeOptions ] } ) ]
-      [ COPY_OPTIONS = ( copyOptions ) ]
-      [ [ WITH ] TAG ( <tag_name> = '<tag_value>' [ , <tag_name> = '<tag_value>' , ... ] ) ]
-      [ COMMENT = '<string_literal>' ]
+        [ COMMENT = '<string_literal>' ]
+        [ [ WITH ] TAG ( <tag_name> = '<tag_value>' [ , <tag_name> = '<tag_value>' , ... ] ) ]
 
     internalStageParams ::=
       [ ENCRYPTION = (TYPE = 'SNOWFLAKE_FULL' | TYPE = 'SNOWFLAKE_SSE') ]
@@ -102,15 +95,13 @@ class InternalStage(Resource):
     props = Props(
         encryption=PropSet(
             "encryption",
-            Props(type=StringProp("type")),
+            Props(type=EnumProp("type", [EncryptionType.SNOWFLAKE_FULL, EncryptionType.SNOWFLAKE_SSE], quoted=True)),
         ),
         directory=PropSet(
             "directory", Props(enable=BoolProp("ENABLE"), refresh_on_create=BoolProp("REFRESH_ON_CREATE"))
         ),
-        # file_format=FileFormatProp("file_format"),
-        copy_options=PropSet("copy_options", copy_options),
-        tags=TagsProp(),
         comment=StringProp("comment"),
+        tags=TagsProp(),
     )
     scope = SchemaScope()
     spec = _InternalStage
@@ -120,9 +111,7 @@ class InternalStage(Resource):
         name: str,
         owner: str = "SYSADMIN",
         encryption: dict[str, EncryptionType] = None,
-        file_format=None,
         directory: dict[str, bool] = None,
-        copy_options: dict = None,
         tags: dict[str, str] = None,
         comment: str = None,
         **kwargs,
@@ -133,9 +122,7 @@ class InternalStage(Resource):
             name=name,
             owner=owner,
             encryption=encryption,
-            file_format=file_format,
             directory=directory,
-            copy_options=copy_options,
             tags=tags,
             comment=comment,
         )
@@ -148,11 +135,9 @@ class _ExternalStage(ResourceSpec):
     owner: str = "SYSADMIN"
     type: StageType = StageType.EXTERNAL
     storage_integration: str = None
-    credentials: dict[str, str] = None
-    encryption: dict[str, str] = None
-    file_format: Union[str, dict] = None
+    credentials: dict[str, str] = field(default_factory=None, metadata={"fetchable": False})
+    encryption: dict[str, str] = field(default_factory=None, metadata={"fetchable": False})
     directory: dict[str, bool] = None
-    copy_options: dict = None
     tags: dict[str, str] = None
     comment: str = None
 
@@ -173,40 +158,49 @@ class ExternalStage(Resource):
     CREATE [ OR REPLACE ] [ { TEMP | TEMPORARY } ] STAGE [ IF NOT EXISTS ] <external_stage_name>
         externalStageParams
         directoryTableParams
-      [ FILE_FORMAT = ( { FORMAT_NAME = '<file_format_name>'
-                         | TYPE = { CSV | JSON | AVRO | ORC | PARQUET | XML } [ formatTypeOptions ] } ) ]
-      [ COPY_OPTIONS = ( copyOptions ) ]
-      [ [ WITH ] TAG ( <tag_name> = '<tag_value>' [ , <tag_name> = '<tag_value>' , ... ] ) ]
-      [ COMMENT = '<string_literal>' ]
+        [ COMMENT = '<string_literal>' ]
+        [ [ WITH ] TAG ( <tag_name> = '<tag_value>' [ , <tag_name> = '<tag_value>' , ... ] ) ]
 
     externalStageParams (for Amazon S3) ::=
-      URL = { 's3://<bucket>[/<path>/]' | 's3gov://<bucket>[/<path>/]' }
+        URL = { 's3://<bucket>[/<path>/]' | 's3gov://<bucket>[/<path>/]' }
 
-      [ { STORAGE_INTEGRATION = <integration_name> }
-        | { CREDENTIALS = ( {  { AWS_KEY_ID = '<string>' AWS_SECRET_KEY = '<string>' [ AWS_TOKEN = '<string>' ] } | AWS_ROLE = '<string>'  } ) ) } ]
-      [ ENCRYPTION = ( [ TYPE = 'AWS_CSE' ] [ MASTER_KEY = '<string>' ] |
-                       [ TYPE = 'AWS_SSE_S3' ] |
-                       [ TYPE = 'AWS_SSE_KMS' [ KMS_KEY_ID = '<string>' ] ] |
-                       [ TYPE = 'NONE' ] ) ]
+        [ { STORAGE_INTEGRATION = <integration_name> } | { CREDENTIALS = ( {  { AWS_KEY_ID = '<string>' AWS_SECRET_KEY = '<string>' [ AWS_TOKEN = '<string>' ] } | AWS_ROLE = '<string>'  } ) } ]
+        [ ENCRYPTION = ( [ TYPE = 'AWS_CSE' ] [ MASTER_KEY = '<string>' ] |
+                        [ TYPE = 'AWS_SSE_S3' ] |
+                        [ TYPE = 'AWS_SSE_KMS' [ KMS_KEY_ID = '<string>' ] ] |
+                        [ TYPE = 'NONE' ] ) ]
 
     externalStageParams (for Google Cloud Storage) ::=
-      URL = 'gcs://<bucket>[/<path>/]'
-      [ STORAGE_INTEGRATION = <integration_name> ]
-      [ ENCRYPTION = ( [ TYPE = 'GCS_SSE_KMS' ] [ KMS_KEY_ID = '<string>' ] | [ TYPE = 'NONE' ] ) ]
+        URL = 'gcs://<bucket>[/<path>/]'
+        [ STORAGE_INTEGRATION = <integration_name> ]
+        [ ENCRYPTION = ( [ TYPE = 'GCS_SSE_KMS' ] [ KMS_KEY_ID = '<string>' ] | [ TYPE = 'NONE' ] ) ]
 
     externalStageParams (for Microsoft Azure) ::=
-      URL = 'azure://<account>.blob.core.windows.net/<container>[/<path>/]'
-      [ { STORAGE_INTEGRATION = <integration_name> } | { CREDENTIALS = ( [ AZURE_SAS_TOKEN = '<string>' ] ) } ]
-       [ ENCRYPTION = ( [ TYPE = 'AZURE_CSE' ] [ MASTER_KEY = '<string>' ] | [ TYPE = 'NONE' ] ) ]
+        URL = 'azure://<account>.blob.core.windows.net/<container>[/<path>/]'
+        [ { STORAGE_INTEGRATION = <integration_name> } | { CREDENTIALS = ( [ AZURE_SAS_TOKEN = '<string>' ] ) } ]
+        [ ENCRYPTION = ( [ TYPE = 'AZURE_CSE' ] [ MASTER_KEY = '<string>' ] | [ TYPE = 'NONE' ] ) ]
 
     externalStageParams (for Amazon S3-compatible Storage) ::=
-      URL = 's3compat://{bucket}[/{path}/]'
-      ENDPOINT = '<s3_api_compatible_endpoint>'
-      [ { CREDENTIALS = ( AWS_KEY_ID = '<string>' AWS_SECRET_KEY = '<string>' ) } ]
+        URL = 's3compat://{bucket}[/{path}/]'
+        ENDPOINT = '<s3_api_compatible_endpoint>'
+        [ { CREDENTIALS = ( AWS_KEY_ID = '<string>' AWS_SECRET_KEY = '<string>' ) } ]
 
-    directoryTableParams (for internal stages) ::=
-      [ DIRECTORY = ( ENABLE = { TRUE | FALSE }
-                      [ REFRESH_ON_CREATE =  { TRUE | FALSE } ] ) ]
+    directoryTableParams (for Amazon S3) ::=
+        [ DIRECTORY = ( ENABLE = { TRUE | FALSE }
+                        [ REFRESH_ON_CREATE =  { TRUE | FALSE } ]
+                        [ AUTO_REFRESH = { TRUE | FALSE } ] ) ]
+
+    directoryTableParams (for Google Cloud Storage) ::=
+        [ DIRECTORY = ( ENABLE = { TRUE | FALSE }
+                        [ AUTO_REFRESH = { TRUE | FALSE } ]
+                        [ REFRESH_ON_CREATE =  { TRUE | FALSE } ]
+                        [ NOTIFICATION_INTEGRATION = '<notification_integration_name>' ] ) ]
+
+    directoryTableParams (for Microsoft Azure) ::=
+        [ DIRECTORY = ( ENABLE = { TRUE | FALSE }
+                        [ REFRESH_ON_CREATE =  { TRUE | FALSE } ]
+                        [ AUTO_REFRESH = { TRUE | FALSE } ]
+                        [ NOTIFICATION_INTEGRATION = '<notification_integration_name>' ] ) ]
     """
 
     resource_type = ResourceType.STAGE
@@ -237,8 +231,6 @@ class ExternalStage(Resource):
                 refresh_on_create=BoolProp("REFRESH_ON_CREATE"),
             ),
         ),
-        # file_format=FileFormatProp("file_format"),
-        copy_options=PropSet("copy_options", copy_options),
         tags=TagsProp(),
         comment=StringProp("comment"),
     )
@@ -254,9 +246,7 @@ class ExternalStage(Resource):
         storage_integration: str = None,
         credentials: dict[str, str] = None,
         encryption: dict[str, EncryptionType] = None,
-        file_format=None,
         directory: dict[str, bool] = None,
-        copy_options: dict = None,
         tags: dict[str, str] = None,
         comment: str = None,
         **kwargs,
@@ -273,9 +263,7 @@ class ExternalStage(Resource):
             storage_integration=storage_integration,
             credentials=credentials,
             encryption=encryption,
-            file_format=file_format,
             directory=directory,
-            copy_options=copy_options,
             tags=tags,
             comment=comment,
         )


### PR DESCRIPTION
Since the last time I worked on Stages, Snowflake has updated their guidance and recommended that you not specify `COPY_OPTIONS` or `FILE_FORMAT` on stages. These are both complex sub-resources, so removing them makes life easy.

This PR includes updated implementations for `InternalStage` and `ExternalStage` as well as a fetch implementation for the former.