### PR TITLE
Fixes install error on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="titan",
     version="0.5.0",
     description="Snowflake infrastructure as code",
-    long_description=open("README.md").read(),
+    long_description=open("README.md", encoding='utf-8').read(),
     long_description_content_type="text/markdown",
     url="https://github.com/teej/titan",
     author="TJ Murphy",


### PR DESCRIPTION
Fixes https://github.com/Titan-Systems/titan/issues/31 install error on Windows due open defaulting to cp1252 rather than utf-8 on Windows.

```
Collecting git+https://github.com/titan-systems/titan.git
  Cloning https://github.com/titan-systems/titan.git to c:\users\m_cairns\appdata\local\temp\pip-req-build-ly3nxg2c
  Running command git clone --filter=blob:none --quiet https://github.com/titan-systems/titan.git 'C:\Users\m_cairns\AppData\Local\Temp\pip-req-build-ly3nxg2c'
  Resolved https://github.com/titan-systems/titan.git to commit a2d57e697f42862331024ab6f92e237ad2acd5d1
  Preparing metadata (pyproject.toml) ... error
  error: subprocess-exited-with-error

  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [20 lines of output]
      Traceback (most recent call last):
        File "C:\Users\m_cairns\AppData\Local\Programs\Python\Python311\Lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 353, in <module>
          main()
        File "C:\Users\m_cairns\AppData\Local\Programs\Python\Python311\Lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "C:\Users\m_cairns\AppData\Local\Programs\Python\Python311\Lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 149, in prepare_metadata_for_build_wheel
          return hook(metadata_directory, config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "C:\Users\m_cairns\AppData\Local\Programs\Python\Python311\Lib\site-packages\setuptools\build_meta.py", line 366, in prepare_metadata_for_build_wheel
          self.run_setup()
        File "C:\Users\m_cairns\AppData\Local\Programs\Python\Python311\Lib\site-packages\setuptools\build_meta.py", line 480, in run_setup
          super().run_setup(setup_script=setup_script)
        File "C:\Users\m_cairns\AppData\Local\Programs\Python\Python311\Lib\site-packages\setuptools\build_meta.py", line 311, in run_setup
          exec(code, locals())
        File "<string>", line 7, in <module>
        File "C:\Users\m_cairns\AppData\Local\Programs\Python\Python311\Lib\encodings\cp1252.py", line 23, in decode
          return codecs.charmap_decode(input,self.errors,decoding_table)[0]
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 2517: character maps to <undefined>
      [end of output]
```