### PR TITLE
check for SNOWFLAKE_AUTHENTICATOR env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ To connect with Snowflake, the CLI uses environment variables. These environment
 * `SNOWFLAKE_ROLE`
 * `SNOWFLAKE_WAREHOUSE`
 * `SNOWFLAKE_MFA_PASSCODE`
+* `SNOWFLAKE_AUTHENTICATOR`
 
 ### CLI Example
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -120,6 +120,7 @@ To connect with Snowflake, the CLI uses environment variables. These environment
 * `SNOWFLAKE_ROLE`
 * `SNOWFLAKE_WAREHOUSE`
 * `SNOWFLAKE_MFA_PASSCODE`
+* `SNOWFLAKE_AUTHENTICATOR`
 
 ### CLI Example
 

--- a/titan/operations/connector.py
+++ b/titan/operations/connector.py
@@ -527,6 +527,7 @@ def get_env_vars() -> dict:
         "SNOWFLAKE_ROLE",
         "SNOWFLAKE_WAREHOUSE",
         "SNOWFLAKE_MFA_PASSCODE",
+        "SNOWFLAKE_AUTHENTICATOR"
     ]:
         value = os.getenv(var, None)
         if value:


### PR DESCRIPTION
Hello!

Our company uses SSO for all of our employee snowflake identities. We login by specifying our login_name and set the authenticator parameter in the snowflake connector parameters to `externalbrowser`. This PR was all that was needed to get Titan to be able to use our accounts on the CLI. 