### PR TITLE
[125] Fix identifier issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
             "build",
             "codespell==2.2.6",
             "pytest-cov",
-            "pytest-profiling",
+            "pytest-profiling!=1.8.0",
             "pytest-xdist",
             "pytest>=6.0",
             "python-dotenv",

--- a/titan/identifiers.py
+++ b/titan/identifiers.py
@@ -211,7 +211,15 @@ def parse_identifier(identifier: str, is_db_scoped=False) -> dict:
     arg_types = None
     if "(" in scoped_name:
         args_start = scoped_name.find("(")
-        scoped_name, args_str = scoped_name[:args_start], scoped_name[args_start:]
+        if scoped_name.endswith('"'):
+            # Handle situation such as `a.b."c(x varchar):varchar(12345)"`
+            scoped_name = scoped_name.rstrip('"')
+            scoped_name, args_str = scoped_name[:args_start], scoped_name[args_start:]
+            scoped_name += '"'
+        else:
+            scoped_name, args_str = scoped_name[:args_start], scoped_name[args_start:]
+        # TODO: This needs to support colons in double quoted identifiers
+        args_str = ":".join(args_str.split(":")[:-1]) if ":" in args_str else args_str  # Strip return type
         arg_types = [arg.strip() for arg in args_str.strip("()").split(",")]
 
     try:


### PR DESCRIPTION
Resolves #125.

- Strips return type from FQN (note: I do not know if this is something that should be done? Help me out.)
- Handles quoted functions

So the following identifier: `a.b."c(x varchar):varchar(12345)"` returns `a.b."c"` as the scoped name and `x varchar` as the arg types, and handles quotes properly and also strips the return type.

However, a limitation of this is that it does not support colons in double quoted identifiers, e.g.

`create view foo ("weird:column": varchar) as ...` will fail here.