### PR TITLE
add static type checking

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -44,9 +44,11 @@ jobs:
         source ./.venv/bin/activate
         python -m pip install --upgrade pip
         make install-dev
-    - name: Run checks (linter, code style, tests)
+    - name: Run checks (linter, code style, static type checks, tests)
       run: |
         source ./.venv/bin/activate
+        ruff check titan/
+        mypy --exclude="titan/resources/.*" --exclude="titan/sql.py" --follow-imports=skip titan/
         python -m pytest --cov=./ --cov-report=xml
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
             "black",
             "build",
             "codespell==2.2.6",
+            "mypy",
             "pytest-cov",
             "pytest-profiling!=1.8.0",
             "pytest-xdist",
@@ -56,6 +57,8 @@ setup(
             "snowflake-cli-labs",
             "tabulate",
             "twine!=5.1.0",
+            "types-pytz",
+            "types-pyyaml",
         ]
     },
 )

--- a/titan/__init__.py
+++ b/titan/__init__.py
@@ -3,7 +3,7 @@ import logging.config
 # __version__ = open("version.md", encoding="utf-8").read().split(" ")[2]
 
 from .blueprint import Blueprint
-from .resources import *
+from .resources import *  # noqa: F403
 
 logger = logging.getLogger("titan")
 

--- a/titan/adapters/permifrost.py
+++ b/titan/adapters/permifrost.py
@@ -100,12 +100,12 @@ def read_permifrost_config(session, file_path):
     with open(file_path, "r") as file:
         config = yaml.safe_load(file)
 
-    version = config.pop("version", None)
-    databases = config.pop("databases", [])
+    version = config.pop("version", None)  # noqa: F841
+    databases = config.pop("databases", [])  # noqa: F841
     roles = config.pop("roles", [])
     users = config.pop("users", [])
-    warehouses = config.pop("warehouses", [])
-    integrations = config.pop("integrations", [])
+    warehouses = config.pop("warehouses", [])  # noqa: F841
+    integrations = config.pop("integrations", [])  # noqa: F841
 
     return [
         # *databases,

--- a/titan/blueprint.py
+++ b/titan/blueprint.py
@@ -3,7 +3,7 @@ import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from queue import Queue
-from typing import Any, Generator, Optional, Sequence, Union, cast
+from typing import Any, Generator, Optional, Iterable, Union, cast, TypeVar, Sequence
 
 import snowflake.connector
 
@@ -28,6 +28,7 @@ from .exceptions import (
 )
 from .identifiers import URN, parse_identifier, parse_URN, resource_label_for_type
 from .privs import (
+    SchemaPriv,
     CREATE_PRIV_FOR_RESOURCE_TYPE,
     PRIVS_FOR_RESOURCE_TYPE,
     AccountPriv,
@@ -51,6 +52,11 @@ from .resources.resource import (
 from .resources.tag import Tag, TaggableResource
 from .scope import AccountScope, DatabaseScope, OrganizationScope, SchemaScope
 
+
+T = TypeVar("T")
+ResourceRef = Union[tuple[ResourceType, str], str]
+
+
 logger = logging.getLogger("titan")
 
 
@@ -59,16 +65,16 @@ class ResourceChange(ABC):
     urn: URN
 
     @abstractmethod
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         pass
 
 
 @dataclass
 class CreateResource(ResourceChange):
     resource_cls: type[Resource]
-    after: dict
+    after: dict[str, str]
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Union[str, dict[str, str]]]:
         return {
             "action": "CREATE",
             "urn": str(self.urn),
@@ -79,9 +85,9 @@ class CreateResource(ResourceChange):
 
 @dataclass
 class DropResource(ResourceChange):
-    before: dict
+    before: dict[str, str]
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Union[str, dict[str, str]]]:
         return {
             "action": "DROP",
             "urn": str(self.urn),
@@ -92,11 +98,11 @@ class DropResource(ResourceChange):
 @dataclass
 class UpdateResource(ResourceChange):
     resource_cls: type[Resource]
-    before: dict
-    after: dict
-    delta: dict
+    before: dict[str, str]
+    after: dict[str, str]
+    delta: dict[str, str]
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Union[str, dict[str, str]]]:
         return {
             "action": "UPDATE",
             "urn": str(self.urn),
@@ -113,7 +119,7 @@ class TransferOwnership(ResourceChange):
     from_owner: str
     to_owner: str
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, str]:
         return {
             "action": "TRANSFER",
             "urn": str(self.urn),
@@ -305,7 +311,7 @@ def dump_plan(plan: Plan, format: str = "json"):
 
         for change in plan:
             action_marker = ""
-            items = []
+            items: Iterable[tuple[str, str]] = []
             if isinstance(change, CreateResource):
                 action_marker = "+"
                 items = change.after.items()
@@ -359,10 +365,10 @@ def print_diffs(diffs):
 def _split_by_scope(
     resources: list[Resource],
 ) -> tuple[list[Resource], list[Resource], list[Resource], list[Resource]]:
-    org_scoped = []
-    acct_scoped = []
-    db_scoped = []
-    schema_scoped = []
+    org_scoped: list[OrganizationScope] = []
+    acct_scoped: list[AccountScope] = []
+    db_scoped: list[DatabaseScope] = []
+    schema_scoped: list[SchemaScope] = []
 
     seen = set()
 
@@ -415,7 +421,7 @@ def _merge_pointers(resources: Sequence[Resource]) -> list[Resource]:
 
     """
 
-    namespace: dict[Any, Resource] = {}
+    namespace: dict[ResourceRef, Resource] = {}
     # Push pointers to the end
     resources = sorted(resources, key=lambda resource: isinstance(resource, ResourcePointer))
 
@@ -433,6 +439,7 @@ def _merge_pointers(resources: Sequence[Resource]) -> list[Resource]:
 
     for resource_or_pointer in resources:
         # Create a unique identifier for the resource
+        resource_id: ResourceRef
         if isinstance(resource_or_pointer, NamedResource):
             resource_id = (resource_or_pointer.resource_type, resource_or_pointer.name)
         else:
@@ -706,12 +713,12 @@ class Blueprint:
 
             for ref in resource.refs:
                 resource_and_ref_share_scope = isinstance(ref.scope, resource.scope.__class__)
-                if ref.container is None and resource_and_ref_share_scope:
+                if ref.container is None and resource.container is not None and resource_and_ref_share_scope:
                     # If a resource requires another, and that secondary resource couldn't be resolved into
                     # an existing scope, then assume it lives in the same container as the original resource
                     resource.container.add(ref)
 
-    def _create_tag_references(self):
+    def _create_tag_references(self) -> None:
         """
         Tag name resolution in Snowflake is special. Tags can be referenced
         by name only. If that tag name is unique in the account, the tag will be applied.
@@ -902,17 +909,17 @@ class Blueprint:
             self._add(resource)
 
 
-def owner_for_change(change: ResourceChange) -> Optional[str]:
+def owner_for_change(change: ResourceChange) -> Optional[ResourceName]:
     if isinstance(change, CreateResource) and "owner" in change.after:
-        return change.after["owner"]
+        return ResourceName(change.after["owner"])
     elif isinstance(change, UpdateResource) and "owner" in change.after:
         # TRANSFER actions occur strictly after CHANGE actions, so we use the before owner
         # as the role for the change
-        return change.before["owner"]
+        return ResourceName(change.before["owner"])
     elif isinstance(change, DropResource) and "owner" in change.before:
-        return change.before["owner"]
+        return ResourceName(change.before["owner"])
     elif isinstance(change, TransferOwnership):
-        return change.from_owner
+        return ResourceName(change.from_owner)
     else:
         return None
 
@@ -1184,9 +1191,9 @@ def compile_plan_to_sql(session_ctx: SessionContext, plan: Plan):
         if isinstance(change, CreateResource):
             if change.urn.resource_type == ResourceType.ROLE_GRANT:
                 if change.after["to_role"] in available_roles:
-                    available_roles.append(change.after["role"])
+                    available_roles.append(ResourceName(change.after["role"]))
             elif change.urn.resource_type == ResourceType.GRANT:
-                grantee_role = change.after["to"]
+                grantee_role = ResourceName(change.after["to"])
                 if grantee_role not in role_privileges:
                     role_privileges[grantee_role] = []
                 for priv in change.after["_privs"]:
@@ -1202,9 +1209,9 @@ def compile_plan_to_sql(session_ctx: SessionContext, plan: Plan):
             elif "owner" in change.after:
                 # When creating any other resource type, creating implies ownership
                 resource_priv_types = PRIVS_FOR_RESOURCE_TYPE[change.urn.resource_type]
+                owner_role = ResourceName(str(change.after["owner"]))
                 if resource_priv_types and "OWNERSHIP" in resource_priv_types:
                     ownership_priv = resource_priv_types("OWNERSHIP")
-                    owner_role = str(change.after["owner"])
                     if owner_role not in role_privileges:
                         role_privileges[owner_role] = []
                     role_privileges[owner_role].append(
@@ -1218,7 +1225,7 @@ def compile_plan_to_sql(session_ctx: SessionContext, plan: Plan):
                 if change.urn.resource_type == ResourceType.DATABASE:
                     role_privileges[owner_role].append(
                         GrantedPrivilege.from_grant(
-                            privilege=PRIVS_FOR_RESOURCE_TYPE[ResourceType.SCHEMA]("OWNERSHIP"),
+                            privilege=SchemaPriv("OWNERSHIP"),
                             granted_on=ResourceType.SCHEMA,
                             name=str(change.urn.fqn) + ".PUBLIC",
                         )
@@ -1226,12 +1233,12 @@ def compile_plan_to_sql(session_ctx: SessionContext, plan: Plan):
     return sql_commands
 
 
-def topological_sort(resource_set: set, references: set):
+def topological_sort(resource_set: set[T], references: set[tuple[T, T]]) -> dict[T, int]:
     # Kahn's algorithm
 
     # Compute in-degree (# of inbound edges) for each node
-    in_degrees = {}
-    outgoing_edges = {}
+    in_degrees: dict[T, int] = {}
+    outgoing_edges: dict[T, set[T]] = {}
 
     for node in resource_set:
         in_degrees[node] = 0
@@ -1242,7 +1249,7 @@ def topological_sort(resource_set: set, references: set):
         outgoing_edges[node].add(ref)
 
     # Put all nodes with 0 in-degree in a queue
-    queue = Queue()
+    queue: Queue = Queue()
     for node, in_degree in in_degrees.items():
         if in_degree == 0:
             queue.put(node)

--- a/titan/blueprint.py
+++ b/titan/blueprint.py
@@ -134,7 +134,7 @@ Plan = list[ResourceChange]
 
 
 def plan_from_dict(plan_dict: dict) -> Plan:
-    changes = []
+    changes: list[ResourceChange] = []
     for change in plan_dict:
         action = change["action"]
         if action == "CREATE":

--- a/titan/cli.py
+++ b/titan/cli.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any
 
 import click
 import yaml
@@ -75,7 +76,7 @@ def titan_cli():
 def plan(config_file, json_output, output_file, vars: dict, allowlist, run_mode):
     """Generate an execution plan based on your configuration"""
     yaml_config = load_config(config_file)
-    cli_config = {}
+    cli_config: dict[str, Any] = {}
     if vars:
         cli_config["vars"] = vars
     if run_mode:

--- a/titan/data_types.py
+++ b/titan/data_types.py
@@ -1,9 +1,9 @@
-from typing import Union
+from typing import Optional, Union
 
 from .enums import DataType
 
 
-def convert_to_canonical_data_type(data_type: Union[str, DataType, None]) -> str:
+def convert_to_canonical_data_type(data_type: Union[str, DataType, None]) -> Optional[str]:
     if data_type is None:
         return None
     if isinstance(data_type, DataType):

--- a/titan/enums.py
+++ b/titan/enums.py
@@ -20,7 +20,7 @@ class _Parseable(EnumMeta):
         return child in self.__members__
 
 
-class ParseableEnum(Enum, metaclass=_Parseable):
+class ParseableEnum(str, Enum, metaclass=_Parseable):
     def __str__(self):
         return str(self.value)
 

--- a/titan/gitops.py
+++ b/titan/gitops.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional
+from typing import Any, Optional
 
 from inflection import pluralize
 
@@ -186,13 +186,13 @@ def _resources_for_config(config: dict):
     return resources
 
 
-def collect_blueprint_config(yaml_config: dict, cli_config: Optional[dict] = None) -> BlueprintConfig:
+def collect_blueprint_config(yaml_config: dict, cli_config: Optional[dict[str, Any]] = None) -> BlueprintConfig:
 
     if cli_config is None:
         cli_config = {}
 
     config = yaml_config.copy()
-    blueprint_args = {}
+    blueprint_args: dict[str, Any] = {}
 
     allowlist = config.pop("allowlist", None)
     if allowlist:
@@ -240,4 +240,4 @@ def collect_blueprint_config(yaml_config: dict, cli_config: Optional[dict] = Non
     if config:
         raise ValueError(f"Unknown keys in config: {config.keys()}")
 
-    return BlueprintConfig(**blueprint_args)
+    return BlueprintConfig(**blueprint_args)  # type: ignore[arg-type]

--- a/titan/operations/blueprint.py
+++ b/titan/operations/blueprint.py
@@ -1,10 +1,13 @@
 from titan.blueprint import Blueprint, plan_from_dict
 from titan.blueprint_config import BlueprintConfig
+from typing import Any
+
+from titan.blueprint import Blueprint
 from titan.gitops import collect_blueprint_config
 from titan.operations.connector import connect
 
 
-def blueprint_plan(yaml_config: dict, cli_config: dict):
+def blueprint_plan(yaml_config: dict, cli_config: dict[str, Any]):
     blueprint_config = collect_blueprint_config(yaml_config, cli_config)
     blueprint = Blueprint.from_config(blueprint_config)
     session = connect()

--- a/titan/operations/blueprint.py
+++ b/titan/operations/blueprint.py
@@ -3,6 +3,8 @@ from titan.blueprint_config import BlueprintConfig
 from typing import Any
 
 from titan.blueprint import Blueprint
+from titan.blueprint import plan_from_dict
+from titan.blueprint_config import BlueprintConfig
 from titan.gitops import collect_blueprint_config
 from titan.operations.connector import connect
 

--- a/titan/operations/blueprint.py
+++ b/titan/operations/blueprint.py
@@ -1,5 +1,3 @@
-from titan.blueprint import Blueprint, plan_from_dict
-from titan.blueprint_config import BlueprintConfig
 from typing import Any
 
 from titan.blueprint import Blueprint

--- a/titan/operations/blueprint.py
+++ b/titan/operations/blueprint.py
@@ -5,6 +5,7 @@ from typing import Any
 from titan.blueprint import Blueprint
 from titan.blueprint import plan_from_dict
 from titan.blueprint_config import BlueprintConfig
+
 from titan.gitops import collect_blueprint_config
 from titan.operations.connector import connect
 

--- a/titan/parse.py
+++ b/titan/parse.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import re
 
 import pyparsing as pp
@@ -28,14 +30,14 @@ ON = Keyword("ON").suppress()
 TO = Keyword("TO").suppress()
 
 
-def Keywords(keywords):
+def Keywords(keywords: str) -> pp.ParserElement:
     words = keywords.split(" ")
     if len(words) == 1:
         return Keyword(words[0])
     return pp.ungroup(pp.And([Keyword(tok) for tok in keywords.split(" ")]).add_parse_action(" ".join))
 
 
-def Literals(keywords):
+def Literals(keywords: str) -> pp.ParserElement:
     return pp.ungroup(pp.And([Literal(tok) for tok in keywords.split(" ")]).add_parse_action(" ".join))
 
 
@@ -334,6 +336,8 @@ class Lexicon:
         for word, action in lexicon.items():
             if isinstance(word, str):
                 word = Keywords(word)
+            if TYPE_CHECKING:
+                assert isinstance(word, pp.ParserElement)
             word = word.set_results_name(str(idx))
             self._words.append(word)
             self._actions.append(action)

--- a/titan/privs.py
+++ b/titan/privs.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Union
 from .enums import ParseableEnum, ResourceType
 
 
@@ -9,7 +9,8 @@ class Priv(ParseableEnum):
 
 @dataclass
 class GrantedPrivilege:
-    privilege: Priv
+    # Union[Priv, str] makes typing work, but probably should be Priv only.
+    privilege: Union[Priv, str]
     on: str  # probably should be FQN
 
     @classmethod

--- a/titan/resource_name.py
+++ b/titan/resource_name.py
@@ -1,6 +1,6 @@
 import re
 from functools import lru_cache
-from typing import Union
+from typing import Any, Union
 
 import pyparsing as pp
 import yaml
@@ -34,6 +34,9 @@ def _name_should_be_quoted(name: str) -> bool:
 
 
 class ResourceName:
+    _name: str
+    _quoted: bool
+
     def __init__(self, name: Union[str, "ResourceName"]) -> None:
         if not isinstance(name, (str, ResourceName)):
             raise RuntimeError(f"ResourceName must be a string or ResourceName, got {type(name)}")
@@ -60,7 +63,7 @@ class ResourceName:
     def __str__(self):
         return f'"{self._name}"' if self._quoted else self._name.upper()
 
-    def __eq__(self, other: Union[str, "ResourceName"]):
+    def __eq__(self, other: Any):
         if not isinstance(other, (ResourceName, str)):
             return False
         if isinstance(other, str):

--- a/titan/resource_tags.py
+++ b/titan/resource_tags.py
@@ -1,6 +1,9 @@
-class ResourceTags:
+from typing import Mapping
+
+
+class ResourceTags(Mapping):
     def __init__(self, tags: dict[str, str]):
-        self.tags = {}
+        self.tags: dict[str, str] = {}
         if isinstance(tags, ResourceTags):
             tags = tags.to_dict()
         for key, value in tags.items():
@@ -20,6 +23,12 @@ class ResourceTags:
 
     def __hash__(self):
         return hash(frozenset(self.tags.items()))
+
+    def __len__(self):
+        return len(self.tags)
+
+    def __iter__(self):
+        return self.tags.__iter__()
 
     def to_dict(self):
         return self.tags.copy()

--- a/titan/resources/external_access_integration.py
+++ b/titan/resources/external_access_integration.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from .resource import Resource, ResourceSpec, NamedResource, ResourcePointer, convert_to_resource
+from .resource import Resource, ResourceSpec, NamedResource, ResourcePointer
 from ..resource_name import ResourceName
 from .network_rule import NetworkRule
 from .role import Role

--- a/titan/resources/external_volume.py
+++ b/titan/resources/external_volume.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from ..enums import ParseableEnum, ResourceType, EncryptionType
 from ..props import (
@@ -7,14 +7,12 @@ from ..props import (
     PropSet,
     Props,
     StringProp,
-    TagsProp,
     PropList,
 )
 from ..resource_name import ResourceName
 from ..scope import AccountScope, AnonymousScope
 from .resource import NamedResource, Resource, ResourceSpec
 from .role import Role
-from .tag import TaggableResource
 
 
 class ExternalVolumeStorageProvider(ParseableEnum):

--- a/titan/resources/warehouse.py
+++ b/titan/resources/warehouse.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Optional, Union
+from typing import Union
 
 from ..enums import AccountEdition, ParseableEnum, ResourceType, WarehouseSize
 from ..props import (

--- a/titan/scope.py
+++ b/titan/scope.py
@@ -35,7 +35,7 @@ class SchemaScope(ResourceScope):
 
 
 class TableScope(ResourceScope):
-    def fully_qualified_name(self, resource_name: ResourceName):
+    def fully_qualified_name(self, _, resource_name: ResourceName):
         raise NotImplementedError
         # return FQN(
         #     name=resource_name.upper(),

--- a/titan/var.py
+++ b/titan/var.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import jinja2.exceptions
 from jinja2 import Environment, StrictUndefined
 
@@ -16,7 +18,7 @@ class VarString:
         except jinja2.exceptions.UndefinedError:
             raise MissingVarException(f"Missing var: {self.string}")
 
-    def __eq__(self, other: str):
+    def __eq__(self, other: Any):
         raise NotImplementedError("VarString does not support equality checks")
 
 


### PR DESCRIPTION
- Add static type checks with `mypy`.
  - I use CLI flags over `pyproject.toml` so that `mypy` on the whole project doesn't exclude things that should be checked (i.e. `titan/resources/`), but it shouldn't block CI.
  - Lots of changes here, some of which are more than just annotations (after all, point of type checking is to find subtle errors). Be sure to review them.
- Ran `ruff lint titan/` and also added it to CI.

Note: some of these changes may impact PR velocity without either pre-commit or a CI job that auto-commits changes identified by `ruff`. However, I will not attempt to impose my devops preferences in that department.