### PR TITLE
fix: fixes for database role grants

### DIFF
--- a/titan/gitops.py
+++ b/titan/gitops.py
@@ -81,6 +81,13 @@ def _resources_from_database_role_grants_config(database_role_grants_config: lis
                     to_role=database_role_grant["to_role"],
                 )
             )
+        elif "to_database_role" in database_role_grant:
+            resources.append(
+                DatabaseRoleGrant(
+                    database_role=database_role_grant["database_role"],
+                    to_database_role=database_role_grant["to_database_role"],
+                )
+            )
         else:
             for role in database_role_grant.get("roles", []):
                 resources.append(


### PR DESCRIPTION
- updates the behavior of the `fetch_database_role_grant` function to mimic the behavior of `fetch_role_grant` in the data provider
  - accounts for differing parameters needed for database role grants
- updates the behavior of the `_resources_from_database_role_grants_config` function in gitops to account for database role grants to other database roles


Hey @teej I have one more for you. Was running into some trouble with database role grants and I think this is the culprit. To be quite honest, I didn't spend much time reading into this. I popped the code from the `fetch_role_grant` function into this one and just updated the code where needed to reflect the difference for database roles, and it worked for my use case.

In case you're interested in reproducing the problem I had:

```
database_role_grants:
  - database_role: example_db.example_db_role
    to_role: example_role_1
  - database_role: example_db.example_db_role
    to_role: example_role_2
```

If you perform the above grants by hand, then run Titan, it will attempt to update the grant for `example_role_2` from `example_role_1` to `example_role_2`.

While testing the above behavior with grants to database roles, I stumbled across another error, which is that if your config is exclusively database role grants to other database roles, they are not correctly parsed. The change I made in the `gitops.py` file addresses that issue.