### PR TITLE
fix: update resource name handling and identifier parsing for emails/login_name for Users

### DIFF
--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -51,8 +51,8 @@ def test_resource_name():
     assert rn._quoted
 
     rn = ResourceName("foo@bar.com")
-    assert str(rn) == '"foo@bar.com"'
-    assert rn._quoted
+    assert str(rn) == "foo@bar.com"
+    assert not rn._quoted
 
 
 def test_resource_name_equality():

--- a/titan/parse_primitives.py
+++ b/titan/parse_primitives.py
@@ -1,6 +1,6 @@
 import pyparsing as pp
 
-Identifier = pp.Word(pp.alphanums + "_", pp.alphanums + "_$") | pp.dbl_quoted_string
+Identifier = pp.Word(pp.alphanums + "_@", pp.alphanums + "_@$") | pp.dbl_quoted_string
 FullyQualifiedIdentifier = (
     pp.delimited_list(Identifier, delim=".", min=4, max=4)
     ^ pp.delimited_list(Identifier, delim=".", min=3, max=3)


### PR DESCRIPTION
SSO/Federated Logins use login_name as lookup for validation of authentication:

https://docs.snowflake.com/en/user-guide/admin-security-fed-auth-configure-idp#okta-setup


Today Titan double quotes login name on create statement.
```
urn::XXXXXXX:user/IKETESTLACEY {
  + name                    = "IKETESTLACEY"
  + owner                   = "USERADMIN"
  + password                = None
  + login_name              = ""IKETESTLACEY@OLOCOM""
  + display_name            = "IKETESTLACEY"
  + first_name              = None
  + middle_name             = None
  + last_name               = None
  + email                   = None
  + must_change_password    = False
  + disabled                = False
  + days_to_expiry          = None
  + mins_to_unlock          = None
  + default_warehouse       = None
  + default_namespace       = None
  + default_role            = None
  + default_secondary_roles = None
  + mins_to_bypass_mfa      = None
  + rsa_public_key          = None
  + rsa_public_key_2        = None
  + comment                 = None
  + network_policy          = None
  + type                    = "NULL"
}
```


This change would reflect the changes below:
```
urn::XXXXXXX:user/IKETESTLACEY {
  + name                    = "IKETESTLACEY"
  + owner                   = "USERADMIN"
  + password                = None
  + login_name              = "IKETESTLACEY@OLOCOM"
  + display_name            = "IKETESTLACEY"
  + first_name              = None
  + middle_name             = None
  + last_name               = None
  + email                   = None
  + must_change_password    = False
  + disabled                = False
  + days_to_expiry          = None
  + mins_to_unlock          = None
  + default_warehouse       = None
  + default_namespace       = None
  + default_role            = None
  + default_secondary_roles = None
  + mins_to_bypass_mfa      = None
  + rsa_public_key          = None
  + rsa_public_key_2        = None
  + comment                 = None
  + network_policy          = None
  + type                    = "NULL"
}
```