### PR TITLE
Update README to include key pair auth details

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ The CLI allows you to `plan` and `apply` a Titan Core YAML config. You can speci
 
 In addition to `plan` and `apply`, the CLI also allows you to `export` resources. This makes it easy to generate a config for an existing Snowflake environment.
 
-To connect with Snowflake, the CLI uses environment variables. The following `are supported:
+To connect with Snowflake, the CLI uses environment variables. The following are supported:
 
 * `SNOWFLAKE_ACCOUNT`
 * `SNOWFLAKE_USER`
@@ -178,6 +178,12 @@ To connect with Snowflake, the CLI uses environment variables. The following `ar
 * `SNOWFLAKE_WAREHOUSE`
 * `SNOWFLAKE_MFA_PASSCODE`
 * `SNOWFLAKE_AUTHENTICATOR`
+
+If using [key-pair auth](https://docs.snowflake.com/en/user-guide/key-pair-auth) instead of password, use the following environment variables in place of `SNOWFLAKE_PASSWORD`:
+* `SNOWFLAKE_PRIVATE_KEY_PATH`
+* `SNOWFLAKE_PRIVATE_KEY_FILE_PWD`
+
+Note: the value for `SNOWFLAKE_AUTHENTICATOR` should be set to `SNOWFLAKE_JWT` when using key-pair auth.
 
 ### CLI Example
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ To connect with Snowflake, the CLI uses environment variables. The following are
 
 If using [key-pair auth](https://docs.snowflake.com/en/user-guide/key-pair-auth) instead of password, use the following environment variables in place of `SNOWFLAKE_PASSWORD`:
 * `SNOWFLAKE_PRIVATE_KEY_PATH`
-* `SNOWFLAKE_PRIVATE_KEY_FILE_PWD`
+* `PRIVATE_KEY_PASSPHRASE` (if using encrypted key)
 
 Note: the value for `SNOWFLAKE_AUTHENTICATOR` should be set to `SNOWFLAKE_JWT` when using key-pair auth.
 


### PR DESCRIPTION
This PR updates the README to include key-pair authentication as a valid method to connect to Snowflake using the CLI. This currently is not documented but [is supported](https://github.com/Titan-Systems/titan/blob/704637e3824cdd57834846ad1f7fa14da5637b61/titan/operations/connector.py#L464) since the connector library is adapted from the [connector library](https://github.com/snowflakedb/snowflake-cli/blob/115aad045913094b474a4b7a92c752fdafb12fa8/src/snowflake/cli/_app/snow_connector.py#L198) from Snowflake's CLI.

The README now includes the environment variables and a brief note on using key-pair auth. Validated this connection method works locally using our own Snowflake account.