### PR TITLE
[FIX]: Resources with quoted names are not fetched

### DIFF
--- a/titan/data_provider.py
+++ b/titan/data_provider.py
@@ -460,21 +460,19 @@ def _show_resources(session: SnowflakeConnection, type_str, fqn: FQN, cacheable:
             )
             return filtered_fetch
         else:
-
+            name = str(fqn.name).replace('"', "")
+            database = str(fqn.database).replace('"', "")
+            schema = str(fqn.schema).replace('"', "")
             if fqn.database is None and fqn.schema is None:
-                return execute(session, f"SHOW {type_str} LIKE '{fqn.name}'", cacheable=cacheable)
+                return execute(session, f"SHOW {type_str} LIKE '{name}'", cacheable=cacheable)
             elif fqn.database is None:
-                return execute(
-                    session, f"SHOW {type_str} LIKE '{fqn.name}' IN SCHEMA {fqn.schema}", cacheable=cacheable
-                )
+                return execute(session, f"SHOW {type_str} LIKE '{name}' IN SCHEMA {schema}", cacheable=cacheable)
             elif fqn.schema is None:
-                return execute(
-                    session, f"SHOW {type_str} LIKE '{fqn.name}' IN DATABASE {fqn.database}", cacheable=cacheable
-                )
+                return execute(session, f"SHOW {type_str} LIKE '{name}' IN DATABASE {database}", cacheable=cacheable)
             else:
                 return execute(
                     session,
-                    f"SHOW {type_str} LIKE '{fqn.name}' IN SCHEMA {fqn.database}.{fqn.schema}",
+                    f"SHOW {type_str} LIKE '{name}' IN SCHEMA {database}.{fqn.schema}",
                     cacheable=cacheable,
                 )
     except ProgrammingError as err:

--- a/titan/data_provider.py
+++ b/titan/data_provider.py
@@ -461,18 +461,18 @@ def _show_resources(session: SnowflakeConnection, type_str, fqn: FQN, cacheable:
             return filtered_fetch
         else:
             name = str(fqn.name).replace('"', "")
-            database = str(fqn.database).replace('"', "")
-            schema = str(fqn.schema).replace('"', "")
             if fqn.database is None and fqn.schema is None:
                 return execute(session, f"SHOW {type_str} LIKE '{name}'", cacheable=cacheable)
             elif fqn.database is None:
-                return execute(session, f"SHOW {type_str} LIKE '{name}' IN SCHEMA {schema}", cacheable=cacheable)
+                return execute(session, f"SHOW {type_str} LIKE '{name}' IN SCHEMA {fqn.schema}", cacheable=cacheable)
             elif fqn.schema is None:
-                return execute(session, f"SHOW {type_str} LIKE '{name}' IN DATABASE {database}", cacheable=cacheable)
+                return execute(
+                    session, f"SHOW {type_str} LIKE '{name}' IN DATABASE {fqn.database}", cacheable=cacheable
+                )
             else:
                 return execute(
                     session,
-                    f"SHOW {type_str} LIKE '{name}' IN SCHEMA {database}.{fqn.schema}",
+                    f"SHOW {type_str} LIKE '{name}' IN SCHEMA {fqn.database}.{fqn.schema}",
                     cacheable=cacheable,
                 )
     except ProgrammingError as err:


### PR DESCRIPTION
## Problem

Try applying a config file like this:

```yaml
roles:
  - name: I-WILL-BE-QUOTED
```

Resource is created successfully the first time. But on subsequent runs, snowflake will complain saying that the resource already exists. The cause of the issue is the "SHOW" statement not finding the already created role.

## Solution

This PR removes the quotes when running the SHOW statement.
The statement ran was `SHOW ROLES LIKE '"I-WILL-BE-QUOTED"'` instead of `SHOW ROLES LIKE 'I-WILL-BE-QUOTED'`.