### PR TITLE
[FIX]: Role grants for quoted role cannot be fetched

### DIFF
--- a/titan/resource_name.py
+++ b/titan/resource_name.py
@@ -15,8 +15,8 @@ def attribute_is_resource_name(attribute: str) -> bool:
 
 @lru_cache(maxsize=1024 * 1024)
 def resource_name_from_snowflake_metadata(name: str) -> "ResourceName":
-    if name.startswith('"') and name.endswith('"'):
-        raise RuntimeError(f"{name} is not from snowflake metadata")
+    # if name.startswith('"') and name.endswith('"'):
+    #     raise RuntimeError(f"{name} is not from snowflake metadata")
     if re.match(r"^[A-Z_][A-Z0-9_]*$", name):
         return ResourceName(name)
     else:


### PR DESCRIPTION
## Problem

Once [this fix](https://github.com/Titan-Systems/titan/pull/202) gets merged, another issue appears:

1. Try to add role grant for a role with a quoted name
2. Run titan apply, role grant gets created
3. Run titan apply again and an exception occurs: `<role name> is not from snowflake metadata`.

## Solution

Comment out a validation done in `resource_name.py`.
I don't know the intention of such validation, but after commenting it out I was able to run everything smoothly.
