### PR TITLE
[BUGFIX] add missing ClientType to auth policy

### DIFF
--- a/titan/resources/authentication_policy.py
+++ b/titan/resources/authentication_policy.py
@@ -26,6 +26,7 @@ class ClientTypes(ParseableEnum):
     SNOWFLAKE_UI = "SNOWFLAKE_UI"
     DRIVERS = "DRIVERS"
     SNOWSQL = "SNOWSQL"
+    SNOWFLAKE_CLI = "SNOWFLAKE_CLI"
 
 
 @dataclass(unsafe_hash=True)


### PR DESCRIPTION
## Problem
Currently you can't manage Authentication Policies with CLIENT_TYPE = SNOWFLAKE_CLI.
[Snowflake Docs](https://docs.snowflake.com/en/sql-reference/sql/create-authentication-policy#optional-parameters)

## Solution
Added SNOWFLAKE_CLI to the ClientTypes. With this change, my tests were successful.

